### PR TITLE
Move docker.mk to separate folder

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/peterj/kapp/internal/artifacts"
 
 	"github.com/fatih/color"
+	"github.com/peterj/kapp/internal/artifacts/dockermake"
 	"github.com/peterj/kapp/internal/artifacts/golang"
 
 	"github.com/spf13/cobra"
@@ -104,6 +105,10 @@ var createCmd = &cobra.Command{
 				}
 
 				for _, e := range helm.ProjectFiles(ApplicationName) {
+					allFiles = append(allFiles, e)
+				}
+
+				for _, e := range dockermake.ProjectFiles() {
 					allFiles = append(allFiles, e)
 				}
 

--- a/internal/artifacts/dockermake/projectfiles.go
+++ b/internal/artifacts/dockermake/projectfiles.go
@@ -1,0 +1,13 @@
+package dockermake
+
+import (
+	"github.com/peterj/kapp/internal/artifacts"
+	dockertemplates "github.com/peterj/kapp/internal/artifacts/dockermake/templates"
+)
+
+// ProjectFiles returns docker.mk project file
+func ProjectFiles() []*artifacts.ProjectFile {
+	return []*artifacts.ProjectFile{
+		artifacts.NewProjectFile(dockertemplates.DockerMkFile, "docker.mk", artifacts.NewDefaultDelims()),
+	}
+}

--- a/internal/artifacts/dockermake/templates/templates.go
+++ b/internal/artifacts/dockermake/templates/templates.go
@@ -1,0 +1,59 @@
+package templates
+
+// DockerMkFile holds the contents of the docker.mk file
+const DockerMkFile = `VERSION=$(shell cat ./{{ .VersionFileName }})
+
+# Docker settings (make sure DOCKER_REGISTRY environment variable is set)
+DOCKERFILE:=Dockerfile
+IMAGE_NAME={{ .ApplicationName }}
+REGISTRY_NAME:=$(DOCKER_REGISTRY)
+FULL_IMAGE_NAME=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
+
+# Kubernetes/Helm settings
+KUBE_NAMESPACE:={{ .ApplicationName }}
+RELEASE_NAME:={{ .ApplicationName }}
+HELM_CHART_NAME:=helm/{{ .ApplicationName }}
+
+# Builds a docker image
+define build_image
+	docker build -f $(1) -t $(2) .
+endef
+
+# Pushes a docker image to registry
+define push_image
+	docker push $(1)
+endef
+
+# Installs a new Helm chart
+define helm_install
+	helm install --name $(1) --namespace $(2) --set=image.repository=$(3) --set=image.tag=$(4) $(5)
+endef
+
+# Upgrades an existing Helm chart
+define helm_upgrade
+	helm upgrade $(1) --namespace $(2) --set=image.repository=$(3) --set=image.tag=$(4) $(5) --recreate-pods
+endef
+
+.PHONY: build.image
+build.image:
+	@echo "-> $@"
+	$(call build_image, $(DOCKERFILE), $(FULL_IMAGE_NAME))
+
+.PHONY: push.image
+push.image:
+	@echo "-> $@"
+	$(call push_image, $(FULL_IMAGE_NAME))
+
+.PHONE: install.app
+install.app:
+	@echo "-> $@"
+	$(call helm_install,$(RELEASE_NAME),$(KUBE_NAMESPACE),$(REGISTRY_NAME)/$(IMAGE_NAME),$(VERSION),$(HELM_CHART_NAME))
+
+.PHONY: upgrade.app
+upgrade.app:
+	@echo "-> $@"
+	$(call helm_upgrade,$(RELEASE_NAME),$(KUBE_NAMESPACE),$(REGISTRY_NAME)/$(IMAGE_NAME),$(VERSION),$(HELM_CHART_NAME))
+
+.PHONY: upgrade
+upgrade: build.image push.image upgrade.app
+`

--- a/internal/artifacts/golang/projectfiles.go
+++ b/internal/artifacts/golang/projectfiles.go
@@ -14,7 +14,6 @@ func ProjectFiles() []*artifacts.ProjectFile {
 		artifacts.NewProjectFile(gotemplates.VersionTxtFile, "VERSION.txt", goTemplateDelimiters),
 		artifacts.NewProjectFile(gotemplates.Dockerfile, "Dockerfile", goTemplateDelimiters),
 		artifacts.NewProjectFile(gotemplates.VersionGo, "version/version.go", goTemplateDelimiters),
-		artifacts.NewProjectFile(gotemplates.DockerMkFile, "docker.mk", goTemplateDelimiters),
 		artifacts.NewProjectFile(gotemplates.MainGo, "main.go", goTemplateDelimiters),
 		artifacts.NewProjectFile(gotemplates.GitIgnore, ".gitignore", goTemplateDelimiters),
 	}

--- a/internal/artifacts/golang/templates/templates.go
+++ b/internal/artifacts/golang/templates/templates.go
@@ -1,4 +1,4 @@
-package template
+package templates
 
 // VersionTxtFile holds the contents of the VERSION.txt
 const VersionTxtFile = `0.1.0`
@@ -90,64 +90,6 @@ var VERSION string
 
 // GITCOMMIT indicates the git hash binary was built off of
 var GITCOMMIT string`
-
-// DockerMkFile holds the contents of the docker.mk file
-const DockerMkFile = `VERSION=$(shell cat ./{{ .VersionFileName }})
-
-# Docker settings (make sure DOCKER_REGISTRY environment variable is set)
-DOCKERFILE:=Dockerfile
-IMAGE_NAME={{ .ApplicationName }}
-REGISTRY_NAME:=$(DOCKER_REGISTRY)
-FULL_IMAGE_NAME=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
-
-# Kubernetes/Helm settings
-KUBE_NAMESPACE:={{ .ApplicationName }}
-RELEASE_NAME:={{ .ApplicationName }}
-HELM_CHART_NAME:=helm/{{ .ApplicationName }}
-
-# Builds a docker image
-define build_image
-	docker build -f $(1) -t $(2) .
-endef
-
-# Pushes a docker image to registry
-define push_image
-	docker push $(1)
-endef
-
-# Installs a new Helm chart
-define helm_install
-	helm install --name $(1) --namespace $(2) --set=image.repository=$(3) --set=image.tag=$(4) $(5)
-endef
-
-# Upgrades an existing Helm chart
-define helm_upgrade
-	helm upgrade $(1) --namespace $(2) --set=image.repository=$(3) --set=image.tag=$(4) $(5) --recreate-pods
-endef
-
-.PHONY: build.image
-build.image:
-	@echo "-> $@"
-	$(call build_image, $(DOCKERFILE), $(FULL_IMAGE_NAME))
-
-.PHONY: push.image
-push.image:
-	@echo "-> $@"
-	$(call push_image, $(FULL_IMAGE_NAME))
-
-.PHONE: install.app
-install.app:
-	@echo "-> $@"
-	$(call helm_install,$(RELEASE_NAME),$(KUBE_NAMESPACE),$(REGISTRY_NAME)/$(IMAGE_NAME),$(VERSION),$(HELM_CHART_NAME))
-
-.PHONY: upgrade.app
-upgrade.app:
-	@echo "-> $@"
-	$(call helm_upgrade,$(RELEASE_NAME),$(KUBE_NAMESPACE),$(REGISTRY_NAME)/$(IMAGE_NAME),$(VERSION),$(HELM_CHART_NAME))
-
-.PHONY: upgrade
-upgrade: build.image push.image upgrade.app
-`
 
 // MainGo holds the contents of the Main.go file
 const MainGo = `package main


### PR DESCRIPTION
Move docker.mk to a separate folder, so it can be reused later by other languages.